### PR TITLE
Use GitHub PyPI token for release publishing

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -50,7 +50,6 @@ jobs:
       url: https://pypi.org/p/houmao
     permissions:
       contents: read
-      id-token: write
 
     steps:
       - name: Download built distributions
@@ -61,4 +60,5 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-
+        with:
+          password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
## Summary
- switch PyPI publishing from trusted publishing to the GitHub  secret
- keep the existing release-driven workflow contract
- align the workflow with the updated repository secret configuration