### PR TITLE
fix(ci): unbreak PR docs preview build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,8 +29,6 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.ref_name }}
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary

Single-commit follow-up to the v0.4.0 release. Removes the broken `ref:` override on the docs checkout step that I introduced earlier in `12c8ce50 ci: build and deploy docs from published GitHub releases`.

The override resolved to `<PR_number>/merge` for `pull_request` events, which is not a valid checkout ref and broke every PR's docs preview build (visible on PR #7's failed `docs / build` check). For `release` events the override was redundant — `actions/checkout@v4`'s default behavior already checks out `refs/tags/<tag-name>` for release events, the pushed commit for push events, and the synthetic merge ref for pull_request events.

Removing the line restores PR builds and leaves release/push behavior unchanged.

## Test plan

- [x] Verified post-fix on devel: `docs` workflow run 24099817375 succeeded both `build` and `deploy` jobs
- [ ] After merge: confirm `docs` on push to main rebuilds and re-deploys Pages with the merge-commit content

## Notes

- This goes to main on its own (not bundled with anything else) so the v0.4.0 release-prep history stays clean.
- The post-merge docs run will deploy Pages from the merge commit. The actual rendered docs content is identical to v0.4.0 — the only change in this PR is `.github/workflows/docs.yml` (a 2-line removal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)