### PR TITLE
docs: fix mail-notifier source link depth

### DIFF
--- a/docs/reference/gateway/operations/mail-notifier.md
+++ b/docs/reference/gateway/operations/mail-notifier.md
@@ -156,6 +156,6 @@ Current source behavior:
 
 ## Source References
 
-- [`src/houmao/agents/realm_controller/gateway_service.py`](../../../src/houmao/agents/realm_controller/gateway_service.py)
-- [`src/houmao/agents/realm_controller/gateway_storage.py`](../../../src/houmao/agents/realm_controller/gateway_storage.py)
-- [`src/houmao/agents/realm_controller/assets/system_prompts/mailbox/mail-notifier.md`](../../../src/houmao/agents/realm_controller/assets/system_prompts/mailbox/mail-notifier.md)
+- [`src/houmao/agents/realm_controller/gateway_service.py`](../../../../src/houmao/agents/realm_controller/gateway_service.py)
+- [`src/houmao/agents/realm_controller/gateway_storage.py`](../../../../src/houmao/agents/realm_controller/gateway_storage.py)
+- [`src/houmao/agents/realm_controller/assets/system_prompts/mailbox/mail-notifier.md`](../../../../src/houmao/agents/realm_controller/assets/system_prompts/mailbox/mail-notifier.md)


### PR DESCRIPTION
## Summary

- One-line fix per link, three lines total in \`docs/reference/gateway/operations/mail-notifier.md\`: \`../../../src/...\` → \`../../../../src/...\`.
- The page lives four levels deep inside \`docs/\`, so three \`..\` hops resolved to \`docs/src/...\` instead of repo-root \`src/...\`. \`docs_hooks.py\` saw the resolved path under \`docs/\` and skipped its GitHub blob rewrite, leaving the raw cross-tree paths in the rendered Markdown. \`mkdocs build --strict\` then 404'd them and aborted the build.
- Net effect of the previous breakage: every release since the bad edit landed kept publishing to PyPI, but the GitHub Pages site stayed frozen at the v0.4.1 build (including v0.4.2).

## Test plan

- [x] \`pixi run docs-build\` locally — \`Documentation built in 2.33 seconds\`, zero warnings
- [ ] On merge to \`main\`, the \`push: branches: [main]\` trigger fires \`docs.yml\`, which builds and deploys Pages from \`main\` HEAD without needing a new release tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)